### PR TITLE
Update confidential_SecretBallot.sol

### DIFF
--- a/contracts/confidential_SecretBallot.sol
+++ b/contracts/confidential_SecretBallot.sol
@@ -52,7 +52,7 @@ contract SecretBallot {
         return votesReceived[candidate];
     }
 
-    function numCandidates() public constant returns(uint count) {
+    function numCandidates() view public returns(uint count) {
         return candidateNames.length;
     }
 


### PR DESCRIPTION
Addresses https://github.com/oasislabs/oasis-box/issues/13

`constant`, an alias for `view`, is no longer valid with the solidity 5 compiler, so we should probably replace it with view to avoid confusion.