### PR TITLE
Moving solidity version to 0.5.0 and various fixes to ensure compilation

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.5.0;
 
 contract Migrations {
     address public owner;
@@ -8,15 +8,15 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    function Migrations() {
+    constructor() public {
         owner = msg.sender;
     }
 
-    function setCompleted(uint completed) restricted {
+    function setCompleted(uint completed) public restricted {
         last_completed_migration = completed;
     }
 
-    function upgrade(address new_address) restricted {
+    function upgrade(address new_address) public restricted {
         Migrations upgraded = Migrations(new_address);
         upgraded.setCompleted(last_completed_migration);
     }

--- a/contracts/confidential_SecretBallot.sol
+++ b/contracts/confidential_SecretBallot.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.0;
 
 contract SecretBallot {
     // The address of the account that created this ballot.
@@ -19,7 +19,7 @@ contract SecretBallot {
     // The total number of votes cast so far. Revealed before voting has ended.
     uint256 public totalVotes;
 
-    constructor(bytes32[] _candidateNames) public {
+    constructor(bytes32[] memory _candidateNames) public {
         ballotCreator = msg.sender;
         candidateNames = _candidateNames;
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "json-loader": "^0.5.4",
     "oasis-compiler": "^1.0.0",
     "style-loader": "^0.13.1",
-    "truffle": "^4.1.14",
+    "truffle-oasis": "^5.0.0",
     "truffle-hdwallet-provider": "^1.0.0-web3one.0",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.3.0"


### PR DESCRIPTION
The secret ballot test was failing in c-k. It turned out to be a consequence of a an older solidity version in the migration scripts. Moved to `0.5.0` and fixed the consequent compilation problems.

The c-k e2e pass now. Once this is in I will remove the explicit mention of this branch from the c-k test script before submitting the c-k changes for review.